### PR TITLE
Update perms, use mounted modpath

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,9 +23,7 @@ This provides you with useful functions that might help you easily accomplish st
 ### How to include in a Magisk Module (If you're not using SKIPUNZIP)
 1. Place `script` (rename to anything you want) in /system/bin or xbin or anywhere you want
 2. Add `mod-util.sh` in root folder of the Magisk module
-3. Add this in **customize.sh**
->set_perm $MODPATH/mod-util.sh 0 0 0777
-4. Add the `ID` of your module in the `ID` of the [script](https://github.com/veez21/mod-util/blob/69f31c10c7528463ae9a1427669939d048bf2f39/script#L7)
+3. Set the `ID` of the [script](https://github.com/veez21/mod-util/blob/69f31c10c7528463ae9a1427669939d048bf2f39/script#L7) to the `id` from your module.prop
 
 ### Functions in mod-util.sh
 

--- a/mod-util.sh
+++ b/mod-util.sh
@@ -70,7 +70,17 @@ fi
 set_perm() {
   chown $2:$3 $1 || return 1
   chmod $4 $1 || return 1
-  [ -z $5 ] && chcon 'u:object_r:system_file:s0' $1 || chcon $5 $1 || return 1
+  (if [ -z $5 ]; then
+    case $1 in
+      *"system/vendor/app/"*) chcon 'u:object_r:vendor_app_file:s0' $1;;
+      *"system/vendor/etc/"*) chcon 'u:object_r:vendor_configs_file:s0' $1;;
+      *"system/vendor/overlay/"*) chcon 'u:object_r:vendor_overlay_file:s0' $1;;
+      *"system/vendor/"*) chcon 'u:object_r:vendor_file:s0' $1;;
+      *) chcon 'u:object_r:system_file:s0' $1;;
+    esac
+  else
+    chcon $5 $1
+  fi) || return 1
 }
 
 # Set perm recursive

--- a/script
+++ b/script
@@ -11,7 +11,7 @@ _name=$(basename $0)
 ls /data >/dev/null 2>&1 || { echo "$ID needs to run as root!"; echo "type 'su' then '$_name'"; exit 1; }
 
 # Magisk Mod Directory
-MOUNTPATH="/data/adb/modules"
+MOUNTPATH="/sbin/.magisk/modules"
 MODDIR="$MOUNTPATH/$ID"
 [ ! -d $MODDIR ] && { echo "Module not detected!"; exit 1; }
 


### PR DESCRIPTION
Magisk mount uses the sbin path rather then the data path so for any mods that self-update, they'll require sbin